### PR TITLE
Custom model

### DIFF
--- a/docs/available_parameters.rst
+++ b/docs/available_parameters.rst
@@ -20,7 +20,7 @@ You can check which parameters are available with:
 (replace x with A, B, or C for Alpha, Bravo, or Charlie)::
 
   SW_OPER_MAGx_LR_1B
-  SW_OPER_EFIx_PL_1B
+  SW_OPER_EFIx_LP_1B
   SW_OPER_IBIxTMS_2F
   SW_OPER_TECxTMS_2F
   SW_OPER_FACxTMS_2F
@@ -43,7 +43,7 @@ For MAG::
 
 For EFI::
 
-  v_SC,v_ion,v_ion_error,E,E_error,dt_LP,n,n_error,T_ion,T_ion_error,T_elec,T_elec_error,U_SC,U_SC_error,v_ion_H,v_ion_H_error,v_ion_V,v_ion_V_error,rms_fit_H,rms_fit_V,var_x_H,var_y_H,var_x_V,var_y_V,dv_mtq_H,dv_mtq_V,SAA,Flags_LP,Flags_LP_n,Flags_LP_T_elec,Flags_LP_U_SC,Flags_TII,Flags_Platform,Maneuver_Id
+  U_orbit,Ne,Ne_error,Te,Te_error,Vs,Vs_error,Flags_LP,Flags_Ne,Flags_Te,Flags_Vs
 
 For IBI::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to VirES-Python-Client's documentation!
   :maxdepth: 2
   :caption: Example notebooks
 
+  notebook_intro
   notebooks/simple_example
 
 .. toctree::

--- a/docs/notebook_intro.rst
+++ b/docs/notebook_intro.rst
@@ -1,0 +1,9 @@
+Introduction to notebooks
+=========================
+
+Jupyter notebooks are a convenient tool for interactive data exploration and are used here to demonstrate usage of ``viresclient``. We encourage users to try out Jupyter for themselves and to consider sharing notebooks with others.
+
+Here is a list of related notebook repositories where you are welcome to submit changes or additions. Please get in touch if you would like your own repository to be listed here.
+
+ - https://github.com/smithara/viresclient_examples
+ - https://github.com/pacesm/jupyter_notebooks

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -40,6 +40,10 @@ Dependencies::
   tqdm
   xarray
 
+There is an unresolved bug with Windows support - see here_.
+
+.. _here: https://github.com/ESA-VirES/VirES-Python-Client/issues/1
+
 Example usage
 -------------
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,7 +1,15 @@
 Release notes
 =============
 
-Changes from v0.2.1 to v0.2.2
+Changes from v0.2.4 to 0.2.5
+----------------------------
+
+- EFI collections have changed from ``SW_OPER_EFIx_PL_1B`` to ``SW_OPER_EFIx_LP_1B``, with different measurement variables
+- Added support for user-defined models by providing a .shc file path as the ``custom_model`` in :meth:`viresclient.SwarmRequest.set_products`. Model evaluations and residuals will then be returned, named as "Custom_Model", in the same way as other models behave.
+- Added alternative input start and end times as ISO-8601 strings to :meth:`viresclient.SwarmRequest.get_between`
+- Minor bug fixes
+
+Changes from v0.2.1 to v0.2.4
 -----------------------------
 
 - Added models CHAOS-6-MMA-Primary and CHAOS-6-MMA-Secondary

--- a/viresclient/_wps/templates/vires_fetch_filtered_data.xml
+++ b/viresclient/_wps/templates/vires_fetch_filtered_data.xml
@@ -16,6 +16,14 @@
       </wps:Data>
     </wps:Input>
     {% endif -%}
+    {% if custom_shc -%}
+    <wps:Input>
+      <ows:Identifier>shc</ows:Identifier>
+      <wps:Data>
+        <wps:ComplexData>{{ custom_shc }}</wps:ComplexData>
+      </wps:Data>
+    </wps:Input>
+    {% endif -%}
     <wps:Input>
       <ows:Identifier>begin_time</ows:Identifier>
       <wps:Data>

--- a/viresclient/_wps/templates/vires_fetch_filtered_data_async.xml
+++ b/viresclient/_wps/templates/vires_fetch_filtered_data_async.xml
@@ -16,6 +16,14 @@
       </wps:Data>
     </wps:Input>
     {% endif -%}
+    {% if custom_shc -%}
+    <wps:Input>
+      <ows:Identifier>shc</ows:Identifier>
+      <wps:Data>
+        <wps:ComplexData>{{ custom_shc }}</wps:ComplexData>
+      </wps:Data>
+    </wps:Input>
+    {% endif -%}
     <wps:Input>
       <ows:Identifier>begin_time</ows:Identifier>
       <wps:Data>


### PR DESCRIPTION
Adds custom model (.shc) support by just passing a file path (as a string) to .set_products()
e.g.:
````
request.set_products(measurements=["B_NEC", "F"],
                     models=["IGRF12"],
                     custom_model="CHAOS-5_core.shc")
