### PR TITLE
AUX_OBS Support

### DIFF
--- a/docs/available_parameters.rst
+++ b/docs/available_parameters.rst
@@ -63,6 +63,18 @@ SW_OPER_AEJxPBS_2F:GroundMagneticDisturbance AEJ_PBS:GroundMagneticDisturbance -
 SW_OPER_AOBxFAC_2F                           AOB_FAC                           Auroral oval boundaries derived from FACs
 ============================================ ================================= ==============================================================
 
+The AUX_OBS collections contain ground magnetic observatory data from `INTERMAGNET <https://intermagnet.github.io/data_conditions.html>`_ and `WDC <http://www.wdc.bgs.ac.uk/>`_. Please note that these data are provided under different usage terms than the ESA data, and must be acknowledged accordingly.
+
+======================== ================ ==============================================================
+Collection full name     Collection type  Description
+======================== ================ ==============================================================
+SW_OPER_AUX_OBSH2\_       AUX_OBSH         Hourly values derived from both WDC and INTERMAGNET data
+SW_OPER_AUX_OBSM2\_       AUX_OBSM         Minute values from INTERMAGNET
+SW_OPER_AUX_OBSS2\_       AUX_OBSS         Second values from INTERMAGNET
+======================== ================ ==============================================================
+
+The AUX_OBS collections contain data from all observatories together (distinguishable by the ``IAGA_code`` variable). Data from a single observatory can be accessed with special collection names like ``SW_OPER_AUX_OBSM2_:ABK`` where ``ABK`` can be replaced with the IAGA code of the observatory. Use :py:meth:`viresclient.SwarmRequest.available_observatories` to find these IAGA codes.
+
 The ``measurements``, ``models``, and ``auxiliaries`` chosen will match the cadence of the ``collection`` chosen.
 
 ----
@@ -99,6 +111,16 @@ AEJ_PBS                           ``Latitude_QD,Longitude_QD,MLT_QD,J_DF_SemiQD,
 AEJ_PBS:GroundMagneticDisturbance ``B_NE``
 AOB_FAC                           ``Latitude_QD,Longitude_QD,MLT_QD,Boundary_Flag,Quality,Pair_Indicator``
 ================================= ================================================================================
+
+AUX_OBS products:
+
+=============== =========================================
+Collection type Available measurement names
+=============== =========================================
+AUX_OBSH        ``B_NEC,F,IAGA_code,Quality,SensorIndex``
+AUX_OBSM        ``B_NEC,F,IAGA_code,Quality``
+AUX_OBSS        ``B_NEC,F,IAGA_code,Quality``
+=============== =========================================
 
 ----
 

--- a/viresclient/_client_swarm.py
+++ b/viresclient/_client_swarm.py
@@ -158,7 +158,8 @@ COLLECTION_REFERENCES = {
             )
 }
 
-IAGA_CODES = ['AAA', 'AAE', 'ABG', 'ABK', 'ABN', 'AGN', 'AIA', 'ALE', 'ALH', 'ALM', 'AML', 'AMS', 'AMT', 'AMU', 'ANN', 'API', 'AQU', 'ARC', 'ARE', 'ARK', 'ARS', 'ASC', 'ASH', 'ASO', 'ASP', 'BAG', 'BDE', 'BDV', 'BEL', 'BFE', 'BFO', 'BGY', 'BJI', 'BJN', 'BLC', 'BLT', 'BMT', 'BNG', 'BOU', 'BOX', 'BRD', 'BRT', 'BRW', 'BSL', 'BYR', 'CAO', 'CAX', 'CBB', 'CBI', 'CCS', 'CDP', 'CKI', 'CLF', 'CLH', 'CMO', 'CNB', 'CNH', 'COI', 'CPA', 'CPL', 'CRP', 'CSY', 'CTA', 'CTO', 'CTS', 'CTX', 'CWE', 'CYG', 'CZT', 'DAL', 'DAV', 'DBN', 'DED', 'DIK', 'DLR', 'DLT', 'DMC', 'DOB', 'DOU', 'DRV', 'DUR', 'DVS', 'EBR', 'EGS', 'EIC', 'EKT', 'ELT', 'ESA', 'ESK', 'ETT', 'EYR', 'FAN', 'FCC', 'FRA', 'FRD', 'FRN', 'FSP', 'FTN', 'FUQ', 'FUR', 'GAN', 'GCK', 'GDH', 'GLM', 'GLN', 'GNA', 'GNG', 'GRM', 'GUA', 'GUI', 'GUL', 'GWC', 'GZH', 'HAD', 'HBA', 'HBK', 'HER', 'HIS', 'HLP', 'HLW', 'HNA', 'HON', 'HRB', 'HRN', 'HTY', 'HUA', 'HVN', 'HYB', 'IBD', 'IPM', 'IQA', 'IRT', 'ISK', 'IZN', 'JAI', 'JCO', 'JRV', 'KAK', 'KDU', 'KEP', 'KGD', 'KHB', 'KIR', 'KIV', 'KLI', 'KMH', 'KNY', 'KNZ', 'KOD', 'KOR', 'KOU', 'KPG', 'KRC', 'KSH', 'KZN', 'LAA', 'LDV', 'LEN', 'LER', 'LGR', 'LIV', 'LMM', 'LNN', 'LNP', 'LON', 'LOV', 'LPB', 'LQA', 'LRM', 'LRV', 'LUA', 'LVV', 'LWI', 'LYC', 'LZH', 'MAB', 'MAW', 'MBC', 'MBO', 'MCP', 'MCQ', 'MEA', 'MFP', 'MGD', 'MID', 'MIR', 'MIZ', 'MLT', 'MMB', 'MMK', 'MNK', 'MOL', 'MOS', 'MRN', 'MUB', 'MUT', 'MZL', 'NAI', 'NAQ', 'NCK', 'NEW', 'NGK', 'NGP', 'NKK', 'NMP', 'NRD', 'NUR', 'NVL', 'NVS', 'NWS', 'OAS', 'ODE', 'OTT', 'PAB', 'PAF', 'PAG', 'PBQ', 'PCU', 'PEG', 'PET', 'PHU', 'PIL', 'PIO', 'PLR', 'PMG', 'PND', 'POD', 'POT', 'PPT', 'PRU', 'PSM', 'PST', 'PTU', 'QGZ', 'QIX', 'QSB', 'QUE', 'QZH', 'RBD', 'RES', 'RKT', 'ROB', 'RSV', 'SAB', 'SBA', 'SBL', 'SCO', 'SED', 'SFS', 'SGE', 'SHE', 'SHL', 'SHU', 'SIL', 'SIT', 'SJG', 'SKT', 'SMG', 'SNA', 'SOD', 'SPA', 'SPG', 'SPT', 'SSH', 'SSO', 'STJ', 'STO', 'SUA', 'SVD', 'SWI', 'SZT', 'TAH', 'TAL', 'TAM', 'TAN', 'TDC', 'TEH', 'TEN', 'TEO', 'TFS', 'THJ', 'THL', 'THY', 'TIK', 'TIR', 'TKH', 'TKT', 'TMK', 'TND', 'TNG', 'TOK', 'TOL', 'TOO', 'TRD', 'TRO', 'TRW', 'TSU', 'TTB', 'TUC', 'TUN', 'UBA', 'UJJ', 'UPS', 'VAL', 'VIC', 'VLA', 'VLJ', 'VNA', 'VOS', 'VQS', 'VSK', 'VSS', 'WAT', 'WHN', 'WHS', 'WIA', 'WIC', 'WIK', 'WIL', 'WIT', 'WNG', 'YAK', 'YKC', 'YSS']
+IAGA_CODES = ['AAA', 'AAE', 'ABG', 'ABK', 'AIA', 'ALE', 'AMS', 'API', 'AQU', 'ARS', 'ASC', 'ASP', 'BDV', 'BEL', 'BFE', 'BFO', 'BGY', 'BJN', 'BLC', 'BMT', 'BNG', 'BOU', 'BOX', 'BRD', 'BRW', 'BSL', 'CBB', 'CBI', 'CDP', 'CKI', 'CLF', 'CMO', 'CNB', 'CNH', 'COI', 'CPL', 'CSY', 'CTA', 'CTS', 'CYG', 'CZT', 'DED', 'DLR', 'DLT', 'DMC', 'DOB', 'DOU', 'DRV', 'DUR', 'EBR', 'ELT', 'ESA', 'ESK', 'EYR', 'FCC', 'FRD', 'FRN', 'FUQ', 'FUR', 'GAN', 'GCK', 'GDH', 'GLM', 'GLN', 'GNA', 'GNG', 'GUA', 'GUI', 'GZH', 'HAD', 'HBK', 'HER', 'HLP', 'HON', 'HRB', 'HRN', 'HUA', 'HYB', 'IPM', 'IQA', 'IRT', 'IZN', 'JAI', 'JCO', 'KAK', 'KDU', 'KEP', 'KHB', 'KIR', 'KIV', 'KMH', 'KNY', 'KNZ', 'KOU', 'KSH', 'LER', 'LIV', 'LMM', 'LNP', 'LON', 'LOV', 'LRM', 'LRV', 'LVV', 'LYC', 'LZH', 'MAB', 'MAW', 'MBC', 'MBO', 'MCQ', 'MEA', 'MGD', 'MID', 'MIZ', 'MMB', 'MZL', 'NAQ', 'NCK', 'NEW', 'NGK', 'NGP', 'NMP', 'NUR', 'NVS', 'ORC', 'OTT', 'PAF', 'PAG', 'PBQ', 'PEG', 'PET', 'PHU', 'PIL', 'PND', 'PPT', 'PST', 'QGZ', 'QIX', 'QSB', 'QZH', 'RES', 'SBA', 'SBL', 'SFS', 'SHE', 'SHL', 'SHU', 'SIL', 'SIT', 'SJG', 'SOD', 'SPG', 'SPT', 'STJ', 'SUA', 'TAM', 'TAN', 'TDC', 'TEO', 'THJ', 'THL', 'THY', 'TIR', 'TND', 'TRO', 'TRW', 'TSU', 'TUC', 'UPS', 'VAL', 'VIC', 'VNA', 'VOS', 'VSK', 'VSS', 'WHN', 'WIC', 'WIK', 'WNG', 'YAK', 'YKC']
+
 
 class SwarmWPSInputs(WPSInputs):
     """Holds the set of inputs to be passed to the request template for Swarm
@@ -398,6 +399,10 @@ class SwarmRequest(ClientRequest):
             "SW_OPER_AEJ{}PBS_2F:GroundMagneticDisturbance".format(x) for x in "ABC"
         ],
         "AOB_FAC": ["SW_OPER_AOB{}FAC_2F".format(x) for x in "ABC"],
+        "AUX_OBSH": [
+            "SW_OPER_AUX_OBSH2_",
+            *[f"SW_OPER_AUX_OBSH2_:{code}" for code in IAGA_CODES]
+        ],
         "AUX_OBSM": [
             "SW_OPER_AUX_OBSM2_",
             *[f"SW_OPER_AUX_OBSM2_:{code}" for code in IAGA_CODES]
@@ -421,6 +426,7 @@ class SwarmRequest(ClientRequest):
         "IPD": "PT1S",
         "AEJ_LPL": "PT15.6S",
         "AEJ_LPS": "PT1S",
+        "AUX_OBSH": "PT60M",
         "AUX_OBSM": "PT60S",
         "AUX_OBSS": "PT1S"
     }
@@ -484,6 +490,7 @@ class SwarmRequest(ClientRequest):
             "Latitude_QD", "Longitude_QD", "MLT_QD",
             "Boundary_Flag", "Quality", "Pair_Indicator"
             ],
+        "AUX_OBSH": ["B_NEC", "F", "IAGA_code", "Quality", "SensorIndex"],
         "AUX_OBSM": ["B_NEC", "F", "IAGA_code", "Quality"],
         "AUX_OBSS": ["B_NEC", "F", "IAGA_code", "Quality"],
     }

--- a/viresclient/_client_swarm.py
+++ b/viresclient/_client_swarm.py
@@ -611,17 +611,27 @@ class SwarmRequest(ClientRequest):
                 If False then return a dict of available collections.
 
         """
+        # Shorter form of the available collections
+        collections_short = self._available["collections"].copy()
+        collections_short["AUX_OBSS"] = ['SW_OPER_AUX_OBSS2_']
+        collections_short["AUX_OBSM"] = ['SW_OPER_AUX_OBSM2_']
+        collections_short["AUX_OBSH"] = ['SW_OPER_AUX_OBSH2_']
+
         def _filter_collections(groupname):
-            groups = list(self._available["collections"].keys())
-            if groupname in groups:
-                return {groupname:
-                        self._available["collections"][groupname]}
+            """ Reduce the full list to just one group, e.g. "MAG """
+            if groupname:
+                groups = list(collections_short.keys())
+                if groupname in groups:
+                    return {
+                        groupname:
+                        collections_short[groupname]
+                    }
+                else:
+                    raise ValueError("Invalid collection group name")
             else:
-                raise ValueError("Invalid collection group name")
-        if groupname:
-            collections_filtered = _filter_collections(groupname)
-        else:
-            collections_filtered = self._available["collections"]
+                return collections_short
+
+        collections_filtered = _filter_collections(groupname)
         if details:
             print("General References:")
             for i in REFERENCES["General Swarm"]:

--- a/viresclient/_client_swarm.py
+++ b/viresclient/_client_swarm.py
@@ -749,10 +749,11 @@ class SwarmRequest(ClientRequest):
     ):
         """Get list of available observatories from server.
 
-        Search availability by collection, one of:
-        "SW_OPER_AUX_OBSH2_"
-        "SW_OPER_AUX_OBSM2_"
-        "SW_OPER_AUX_OBSS2_"
+        Search availability by collection, one of::
+
+            "SW_OPER_AUX_OBSH2_"
+            "SW_OPER_AUX_OBSM2_"
+            "SW_OPER_AUX_OBSS2_"
 
         Example usage::
 
@@ -768,12 +769,12 @@ class SwarmRequest(ClientRequest):
             )
 
         Args:
-            collection (str): collection name (e.g. "SW_OPER_AUX_OBSM2_")
+            collection (str): collection name (e.g. `"SW_OPER_AUX_OBSM2_"`)
             custom_model (str): as with set_products
             details (bool): returns DataFrame if True
 
         Returns:
-            list or DataFrame: Containing IAGA codes (and start/end times)
+            list or DataFrame: IAGA codes (and start/end times)
 
         """
         def _request_get_observatories(collection=None, start_time=None, end_time=None):

--- a/viresclient/_client_swarm.py
+++ b/viresclient/_client_swarm.py
@@ -155,6 +155,7 @@ COLLECTION_REFERENCES = {
             )
 }
 
+IAGA_CODES = ['AAA', 'AAE', 'ABG', 'ABK', 'ABN', 'AGN', 'AIA', 'ALE', 'ALH', 'ALM', 'AML', 'AMS', 'AMT', 'AMU', 'ANN', 'API', 'AQU', 'ARC', 'ARE', 'ARK', 'ARS', 'ASC', 'ASH', 'ASO', 'ASP', 'BAG', 'BDE', 'BDV', 'BEL', 'BFE', 'BFO', 'BGY', 'BJI', 'BJN', 'BLC', 'BLT', 'BMT', 'BNG', 'BOU', 'BOX', 'BRD', 'BRT', 'BRW', 'BSL', 'BYR', 'CAO', 'CAX', 'CBB', 'CBI', 'CCS', 'CDP', 'CKI', 'CLF', 'CLH', 'CMO', 'CNB', 'CNH', 'COI', 'CPA', 'CPL', 'CRP', 'CSY', 'CTA', 'CTO', 'CTS', 'CTX', 'CWE', 'CYG', 'CZT', 'DAL', 'DAV', 'DBN', 'DED', 'DIK', 'DLR', 'DLT', 'DMC', 'DOB', 'DOU', 'DRV', 'DUR', 'DVS', 'EBR', 'EGS', 'EIC', 'EKT', 'ELT', 'ESA', 'ESK', 'ETT', 'EYR', 'FAN', 'FCC', 'FRA', 'FRD', 'FRN', 'FSP', 'FTN', 'FUQ', 'FUR', 'GAN', 'GCK', 'GDH', 'GLM', 'GLN', 'GNA', 'GNG', 'GRM', 'GUA', 'GUI', 'GUL', 'GWC', 'GZH', 'HAD', 'HBA', 'HBK', 'HER', 'HIS', 'HLP', 'HLW', 'HNA', 'HON', 'HRB', 'HRN', 'HTY', 'HUA', 'HVN', 'HYB', 'IBD', 'IPM', 'IQA', 'IRT', 'ISK', 'IZN', 'JAI', 'JCO', 'JRV', 'KAK', 'KDU', 'KEP', 'KGD', 'KHB', 'KIR', 'KIV', 'KLI', 'KMH', 'KNY', 'KNZ', 'KOD', 'KOR', 'KOU', 'KPG', 'KRC', 'KSH', 'KZN', 'LAA', 'LDV', 'LEN', 'LER', 'LGR', 'LIV', 'LMM', 'LNN', 'LNP', 'LON', 'LOV', 'LPB', 'LQA', 'LRM', 'LRV', 'LUA', 'LVV', 'LWI', 'LYC', 'LZH', 'MAB', 'MAW', 'MBC', 'MBO', 'MCP', 'MCQ', 'MEA', 'MFP', 'MGD', 'MID', 'MIR', 'MIZ', 'MLT', 'MMB', 'MMK', 'MNK', 'MOL', 'MOS', 'MRN', 'MUB', 'MUT', 'MZL', 'NAI', 'NAQ', 'NCK', 'NEW', 'NGK', 'NGP', 'NKK', 'NMP', 'NRD', 'NUR', 'NVL', 'NVS', 'NWS', 'OAS', 'ODE', 'OTT', 'PAB', 'PAF', 'PAG', 'PBQ', 'PCU', 'PEG', 'PET', 'PHU', 'PIL', 'PIO', 'PLR', 'PMG', 'PND', 'POD', 'POT', 'PPT', 'PRU', 'PSM', 'PST', 'PTU', 'QGZ', 'QIX', 'QSB', 'QUE', 'QZH', 'RBD', 'RES', 'RKT', 'ROB', 'RSV', 'SAB', 'SBA', 'SBL', 'SCO', 'SED', 'SFS', 'SGE', 'SHE', 'SHL', 'SHU', 'SIL', 'SIT', 'SJG', 'SKT', 'SMG', 'SNA', 'SOD', 'SPA', 'SPG', 'SPT', 'SSH', 'SSO', 'STJ', 'STO', 'SUA', 'SVD', 'SWI', 'SZT', 'TAH', 'TAL', 'TAM', 'TAN', 'TDC', 'TEH', 'TEN', 'TEO', 'TFS', 'THJ', 'THL', 'THY', 'TIK', 'TIR', 'TKH', 'TKT', 'TMK', 'TND', 'TNG', 'TOK', 'TOL', 'TOO', 'TRD', 'TRO', 'TRW', 'TSU', 'TTB', 'TUC', 'TUN', 'UBA', 'UJJ', 'UPS', 'VAL', 'VIC', 'VLA', 'VLJ', 'VNA', 'VOS', 'VQS', 'VSK', 'VSS', 'WAT', 'WHN', 'WHS', 'WIA', 'WIC', 'WIK', 'WIL', 'WIT', 'WNG', 'YAK', 'YKC', 'YSS']
 
 class SwarmWPSInputs(WPSInputs):
     """Holds the set of inputs to be passed to the request template for Swarm
@@ -209,11 +210,17 @@ class SwarmWPSInputs(WPSInputs):
 
     @staticmethod
     def _spacecraft_from_collection(collection):
-        """Identify spacecraft from collection name."""
-        # 12th character in name, e.g. SW_OPER_MAGx_LR_1B
-        sc = collection[11]
-        sc_to_name = {"A": "Alpha", "B": "Bravo", "C": "Charlie", "_": "NSC"}
-        return sc_to_name[sc]
+        """Identify spacecraft (or ground observatory name) from collection name."""
+        if "AUX_OBS" in collection:
+            name = "AUX_OBS"
+            if ":" in collection:
+                name = f"{name}:{collection[19:22]}"
+        else:
+            # 12th character in name, e.g. SW_OPER_MAGx_LR_1B
+            sc = collection[11]
+            sc_to_name = {"A": "Alpha", "B": "Bravo", "C": "Charlie", "_": "NSC"}
+            name = sc_to_name[sc]
+        return name
 
     def set_collections(self, collections):
         """Restructure given list of collections as dict required by VirES."""
@@ -388,7 +395,15 @@ class SwarmRequest(ClientRequest):
             "SW_OPER_AEJ{}PBS_2F:GroundMagneticDisturbance".format(x) for x in "ABC"
         ],
         "AOB_FAC": ["SW_OPER_AOB{}FAC_2F".format(x) for x in "ABC"],
-        }
+        "AUX_OBSM": [
+            "SW_OPER_AUX_OBSM2_",
+            *[f"SW_OPER_AUX_OBSM2_:{code}" for code in IAGA_CODES]
+        ],
+        "AUX_OBSS": [
+            "SW_OPER_AUX_OBSS2_",
+            *[f"SW_OPER_AUX_OBSS2_:{code}" for code in IAGA_CODES]
+        ]
+    }
 
     # These are not necessarily real sampling steps, but are good enough to use
     # for splitting long requests into chunks
@@ -403,6 +418,8 @@ class SwarmRequest(ClientRequest):
         "IPD": "PT1S",
         "AEJ_LPL": "PT15.6S",
         "AEJ_LPS": "PT1S",
+        "AUX_OBSM": "PT60S",
+        "AUX_OBSS": "PT1S"
     }
 
     PRODUCT_VARIABLES = {
@@ -464,7 +481,9 @@ class SwarmRequest(ClientRequest):
             "Latitude_QD", "Longitude_QD", "MLT_QD",
             "Boundary_Flag", "Quality", "Pair_Indicator"
             ],
-        }
+        "AUX_OBSM": ["B_NEC", "F", "IAGA_code", "Quality"],
+        "AUX_OBSS": ["B_NEC", "F", "IAGA_code", "Quality"],
+    }
 
     AUXILIARY_VARIABLES = [
         "Timestamp", "Latitude", "Longitude", "Radius", "Spacecraft",
@@ -475,7 +494,7 @@ class SwarmRequest(ClientRequest):
         "SunRightAscension", "SunAzimuthAngle", "SunZenithAngle",
         "SunLongitude", "SunVector", "DipoleAxisVector", "NGPLatitude",
         "NGPLongitude", "DipoleTiltAngle",
-        ]
+    ]
 
     MAGNETIC_MODEL_VARIABLES = ["F", "B_NEC"]
 
@@ -490,7 +509,7 @@ class SwarmRequest(ClientRequest):
         "MIO_SHA_2D-Primary", "MIO_SHA_2D-Secondary",
         "AMPS",
         "MCO_SHA_2X", "CHAOS", "CHAOS-MMA", "MMA_SHA_2C", "MMA_SHA_2F", "MIO_SHA_2C", "MIO_SHA_2D", "SwarmCI",
-        ]
+    ]
 
     def __init__(self, url=None, username=None, password=None, token=None,
                  config=None, logging_level="NO_LOGGING"):

--- a/viresclient/_wps/templates/vires_get_observatories.xml
+++ b/viresclient/_wps/templates/vires_get_observatories.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<wps:Execute version="1.0.0" service="WPS" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1">
+  <ows:Identifier>vires:get_observatories</ows:Identifier>
+  <wps:DataInputs>
+    <wps:Input>
+      <ows:Identifier>collection_id</ows:Identifier>
+      <wps:Data>
+        <wps:LiteralData>{{ collection_id }}</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    {% if begin_time -%}
+    <wps:Input>
+      <ows:Identifier>begin_time</ows:Identifier>
+      <wps:Data>
+        <wps:LiteralData>{{ begin_time| d2s }}</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    <wps:Input>
+      <ows:Identifier>end_time</ows:Identifier>
+      <wps:Data>
+        <wps:LiteralData>{{ end_time|d2s }}</wps:LiteralData>
+      </wps:Data>
+    </wps:Input>
+    {% endif -%}
+  </wps:DataInputs>
+  <wps:ResponseForm>
+    <wps:RawDataOutput mimeType="{{ response_type }}">
+      <ows:Identifier>output</ows:Identifier>
+    </wps:RawDataOutput>
+  </wps:ResponseForm>
+</wps:Execute>


### PR DESCRIPTION
Adds the `AUX_OBS` collections (`"SW_OPER_AUX_OBSH2_", "SW_OPER_AUX_OBSM2_", "SW_OPER_AUX_OBSS2_"`)

`"SW_OPER_AUX_OBSH2_"` should be disabled before release as this is currently the prototype support based on TXT files converted by EOX

Basic data acknowledgements are implemented by outputting a notice when `.set_collection` is called with one of the AUX_OBS options

Additional method: `SwarmRequest.available_observatories()` can be used to identify IAGA codes of observatories present in each collection (and optionally at specific time intervals)