### PR TITLE
Allow Jinja2 v3 in installation

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,11 @@ Release notes
 Change log
 ----------
 
+Changes from 0.10.0 to 0.10.1
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Update Jinja2 dependency
+
 Changes from 0.9.1 to 0.10.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     },
     python_requires='>=3.6',
     install_requires=[
-        'Jinja2>=2.10, <3.0.0',
+        'Jinja2>=2.10, <4.0.0',
         'pandas>=0.18, <2.0.0',
         'cdflib>=0.3.9, <=0.3.20',
         'tables>=3.4.4, <4.0.0',

--- a/viresclient/__init__.py
+++ b/viresclient/__init__.py
@@ -37,4 +37,4 @@ from ._api.token import TokenManager
 from . import _data
 
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"


### PR DESCRIPTION
viresclient was holding back the version of Jinja2 (to v2). Could cause a problem with some libraries within a conda environment that are expecting v3