### PR TITLE
Fix bug in multi-file loading xarray for Swarm

### DIFF
--- a/src/viresclient/_data_handling.py
+++ b/src/viresclient/_data_handling.py
@@ -773,7 +773,12 @@ class ReturnedData:
             return None
         elif len(ds_list) == 1:
             ds = ds_list[0]
+        elif "Timestamp" in ds_list[0].dims:
+            # Address simpler concatenation case for VirES for Swarm
+            # "Timestamp" always exists for Swarm, but is not present in Aeolus
+            ds = xarray.concat(ds_list, dim="Timestamp")
         else:
+            # Address complex concatenation case for VirES for Aeolus
             dims = [d for d in list(ds_list[0].dims) if "array" not in d]
             if dims == []:
                 return None
@@ -789,14 +794,6 @@ class ReturnedData:
                         )
                     )
                 ds = xarray.merge(ds_list_per_dim)
-        # # Test this other option:
-        # ds = self.contents[0].as_xarray()
-        # for d in self.contents[1:]:
-        #     ds = xarray.concat([ds, d.as_xarray()], dim="Timestamp")
-        # return ds
-        #
-        # https://github.com/pydata/xarray/issues/1379
-        # concat is slow. Maybe try extracting numpy arrays and rebuilding ds
 
         # Set the original data sources and models used as metadata
         # only for cdf data types


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/ESA-VirES/VirES-Python-Client/pull/71 where multi-file Swarm data is not handled correctly when concatenating the output into xarray. 

e.g. 
```python
from viresclient import SwarmRequest

request = SwarmRequest()
request.set_collection("SW_OPER_MAGA_LR_1B")
request.set_products(
    measurements=["B_NEC"],
)
request.set_range_filter("Latitude", 50, 51)
data = request.get_between("2015-01-01T00:00:00Z", "2015-03-01T00:00:00Z", )
print(data.as_xarray())
```
resulted in 
```
<xarray.Dataset>
Dimensions:     (Timestamp: 28355, NEC: 6)
Coordinates:
  * Timestamp   (Timestamp) datetime64[ns] 2015-01-01T00:00:12 ... 2015-02-28...
  * NEC         (NEC) <U1 'N' 'E' 'C' 'N' 'E' 'C'
Data variables:
    Spacecraft  (Timestamp) object 'A' 'A' 'A' 'A' 'A' ... 'A' 'A' 'A' 'A' 'A'
    Longitude   (Timestamp) float64 -147.1 -147.1 -147.1 ... -37.2 -37.2 -37.2
    Latitude    (Timestamp) float64 50.95 50.89 50.82 ... 50.85 50.91 50.98
    Radius      (Timestamp) float64 6.83e+06 6.83e+06 ... 6.827e+06 6.827e+06
Attributes:
    Sources:         ['SW_OPER_MAGA_LR_1B_20150101T000000_20150101T235959_050...
    MagneticModels:  []
    RangeFilters:    ['Latitude:50,51']

```
where the B_NEC variable fails to be output.

This change fixes this so that we get
```
<xarray.Dataset>
Dimensions:     (Timestamp: 28355, NEC: 3)
Coordinates:
  * Timestamp   (Timestamp) datetime64[ns] 2015-01-01T00:00:12 ... 2015-02-28...
  * NEC         (NEC) <U1 'N' 'E' 'C'
Data variables:
    Spacecraft  (Timestamp) object 'A' 'A' 'A' 'A' 'A' ... 'A' 'A' 'A' 'A' 'A'
    Latitude    (Timestamp) float64 50.95 50.89 50.82 ... 50.85 50.91 50.98
    Longitude   (Timestamp) float64 -147.1 -147.1 -147.1 ... -37.2 -37.2 -37.2
    B_NEC       (Timestamp, NEC) float64 1.543e+04 4.194e+03 ... 3.778e+04
    Radius      (Timestamp) float64 6.83e+06 6.83e+06 ... 6.827e+06 6.827e+06
Attributes:
    Sources:         ['SW_OPER_MAGA_LR_1B_20150101T000000_20150101T235959_050...
    MagneticModels:  []
    RangeFilters:    ['Latitude:50,51']
```
as expected.

I just make use of the coincidence that Swarm data contains "Timestamp" while Aeolus does not...