### PR TITLE
Increase minimal python version test to 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-latest.yml
+++ b/.github/workflows/test-latest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.7", "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dynamic = ["version"]
 dependencies = [
     "cdflib >= 0.3.9",
     "Jinja2 >= 2.10",
-    "netCDF4 >= 1.5.3",
+    "netCDF4 >= 1.5.3; python_version>=3.8",
+    "netCDF4 >= 1.5.3, <= 1.5.8; python_version<=3.7",
     "pandas >= 0.18",
     "requests >= 2.0.0",
     "tables >= 3.4.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dynamic = ["version"]
 dependencies = [
     "cdflib >= 0.3.9",
     "Jinja2 >= 2.10",
-    "netCDF4 >= 1.5.3; python_version>=3.8",
-    "netCDF4 >= 1.5.3, <= 1.5.8; python_version<=3.7",
+    "netCDF4 >= 1.5.3; python_version>='3.8'",
+    "netCDF4 >= 1.5.3, <= 1.5.8; python_version<='3.7'",
     "pandas >= 0.18",
     "requests >= 2.0.0",
     "tables >= 3.4.4",

--- a/src/viresclient/__init__.py
+++ b/src/viresclient/__init__.py
@@ -35,4 +35,4 @@ from ._client_swarm import SwarmRequest
 from ._config import ClientConfig, set_token
 from ._data_handling import ReturnedData, ReturnedDataFile
 
-__version__ = "0.11.1"
+__version__ = "0.11.2-a1"


### PR DESCRIPTION
Dropping tests of python 3.6 on CI because 3.6 is no longer directly supported by github runners

Also limited range of netCDF4 versions (when using Python <3.8) because of install failure on Windows for python 3.7 due to there being no wheels available