### PR TITLE
Fix for pandas 2.x

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,11 @@ Release notes
 Change log
 ----------
 
+Changes from 0.11.4 to 0.11.5
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix :py:meth:`viresclient.SwarmRequest.available_times` usage with pandas 2.x
+
 Changes from 0.11.3 to 0.11.4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/viresclient/__init__.py
+++ b/src/viresclient/__init__.py
@@ -35,4 +35,4 @@ from ._client_swarm import SwarmRequest
 from ._config import ClientConfig, set_token
 from ._data_handling import ReturnedData, ReturnedDataFile
 
-__version__ = "0.11.4"
+__version__ = "0.11.5"

--- a/src/viresclient/_client.py
+++ b/src/viresclient/_client.py
@@ -671,6 +671,10 @@ class ClientRequest:
         response = self._get(request, asynchronous=False, show_progress=False)
         df = read_csv(StringIO(str(response, "utf-8")))
         # Convert to datetime objects
-        df["starttime"] = to_datetime(df["starttime"], format="ISO8601")
-        df["endtime"] = to_datetime(df["endtime"], format="ISO8601")
+        try:
+            df["starttime"] = to_datetime(df["starttime"], format="ISO8601")
+            df["endtime"] = to_datetime(df["endtime"], format="ISO8601")
+        except ValueError:
+            df["starttime"] = to_datetime(df["starttime"])
+            df["endtime"] = to_datetime(df["endtime"])
         return df

--- a/src/viresclient/_client.py
+++ b/src/viresclient/_client.py
@@ -671,6 +671,6 @@ class ClientRequest:
         response = self._get(request, asynchronous=False, show_progress=False)
         df = read_csv(StringIO(str(response, "utf-8")))
         # Convert to datetime objects
-        df["starttime"] = to_datetime(df["starttime"])
-        df["endtime"] = to_datetime(df["endtime"])
+        df["starttime"] = to_datetime(df["starttime"], format="ISO8601")
+        df["endtime"] = to_datetime(df["endtime"], format="ISO8601")
         return df


### PR DESCRIPTION
Fixes a failure in `available_times()` with pandas 2.x