### PR TITLE
Adjust collection labelling so that multiple VOBS can be fetched

### DIFF
--- a/src/viresclient/__init__.py
+++ b/src/viresclient/__init__.py
@@ -35,4 +35,4 @@ from ._client_swarm import SwarmRequest
 from ._config import ClientConfig, set_token
 from ._data_handling import ReturnedData, ReturnedDataFile
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"

--- a/src/viresclient/_client_swarm.py
+++ b/src/viresclient/_client_swarm.py
@@ -308,11 +308,9 @@ class SwarmWPSInputs(WPSInputs):
     @staticmethod
     def _spacecraft_from_collection(collection):
         """Identify spacecraft (or ground observatory name) from collection name."""
-        if "AUX_OBS" in collection:
-            name = "AUX_OBS"
-            if ":" in collection:
-                name = f"{name}:{collection[19:22]}"
-        elif collection[:3] == "SW_":
+        if "AUX_OBS" in collection or "VOBS" in collection:
+            name = collection
+        elif (collection[:3] == "SW_"):
             # 12th character in name, e.g. SW_OPER_MAGx_LR_1B
             sc = collection[11]
             sc_to_name = {"A": "Alpha", "B": "Bravo", "C": "Charlie"}

--- a/src/viresclient/_client_swarm.py
+++ b/src/viresclient/_client_swarm.py
@@ -310,7 +310,7 @@ class SwarmWPSInputs(WPSInputs):
         """Identify spacecraft (or ground observatory name) from collection name."""
         if "AUX_OBS" in collection or "VOBS" in collection:
             name = collection
-        elif (collection[:3] == "SW_"):
+        elif collection[:3] == "SW_":
             # 12th character in name, e.g. SW_OPER_MAGx_LR_1B
             sc = collection[11]
             sc_to_name = {"A": "Alpha", "B": "Bravo", "C": "Charlie"}


### PR DESCRIPTION
Fixes bug that meant that requests for multiple VOBS sites in one go would fail, for example using:
```
set_collection("SW_OPER_VOBS_4M_2_:N06E037", "SW_OPER_VOBS_4M_2_:N06E048"
```