### PR TITLE
Pytest: Ignore DeprecationWarning from pandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ viresclient = "viresclient.commands.viresclient:start"
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore:(\nPyarrow will become a required dependency of pandas):DeprecationWarning",
+]
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
This fixes CI failure from Pandas warning about Pyarrow:

```
E   DeprecationWarning: 
E   Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
E   (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
E   but was not found to be installed on your system.
E   If this would cause problems for you,
E   please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```