### PR TITLE
VirES WPS fixes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,14 @@ Release notes
 Change log
 ----------
 
+Changes from 0.12.1 to 0.12.2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Internal WPS fixes which may be required to access the server in the future**
+- Improved robustness during asynchronous requests (the client now repeats the failed job status polling 3 times with 20 seconds interval)
+
+See `PR#121 <https://github.com/ESA-VirES/VirES-Python-Client/pull/121>`_ for details
+
 Changes from 0.12.0 to 0.12.1
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/viresclient/__init__.py
+++ b/src/viresclient/__init__.py
@@ -35,4 +35,4 @@ from ._client_swarm import SwarmRequest
 from ._config import ClientConfig, set_token
 from ._data_handling import ReturnedData, ReturnedDataFile
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"

--- a/src/viresclient/_client.py
+++ b/src/viresclient/_client.py
@@ -70,6 +70,8 @@ LEVELS = {
     "NO_LOGGING": CRITICAL + 1,
 }
 
+DEFAULT_LOGGING_LEVEL = "ERROR"
+
 # File type to WPS output name
 RESPONSE_TYPES = {
     "csv": "text/csv",
@@ -258,7 +260,7 @@ class ClientRequest:
         url=None,
         token=None,
         config=None,
-        logging_level="NO_LOGGING",
+        logging_level=DEFAULT_LOGGING_LEVEL,
         server_type=None,
     ):
         self._server_type = server_type

--- a/src/viresclient/_client_aeolus.py
+++ b/src/viresclient/_client_aeolus.py
@@ -3,7 +3,7 @@ import json
 
 import pandas as pd
 
-from ._client import ClientRequest, WPSInputs
+from ._client import ClientRequest, WPSInputs, DEFAULT_LOGGING_LEVEL
 from ._data import CONFIG_AEOLUS
 from ._data_handling import ReturnedDataFile
 
@@ -222,7 +222,7 @@ class AeolusRequest(ClientRequest):
 
     """
 
-    def __init__(self, url=None, token=None, config=None, logging_level="NO_LOGGING"):
+    def __init__(self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL):
         super().__init__(url, token, config, logging_level, server_type="Aeolus")
         # self._available = self._set_available_data()
         self._request_inputs = AeolusWPSInputs()

--- a/src/viresclient/_client_aeolus.py
+++ b/src/viresclient/_client_aeolus.py
@@ -3,7 +3,7 @@ import json
 
 import pandas as pd
 
-from ._client import ClientRequest, WPSInputs, DEFAULT_LOGGING_LEVEL
+from ._client import DEFAULT_LOGGING_LEVEL, ClientRequest, WPSInputs
 from ._data import CONFIG_AEOLUS
 from ._data_handling import ReturnedDataFile
 
@@ -222,7 +222,9 @@ class AeolusRequest(ClientRequest):
 
     """
 
-    def __init__(self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL):
+    def __init__(
+        self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL
+    ):
         super().__init__(url, token, config, logging_level, server_type="Aeolus")
         # self._available = self._set_available_data()
         self._request_inputs = AeolusWPSInputs()

--- a/src/viresclient/_client_swarm.py
+++ b/src/viresclient/_client_swarm.py
@@ -12,7 +12,7 @@ from warnings import warn
 from pandas import read_csv
 from tqdm import tqdm
 
-from ._client import TEMPLATE_FILES, ClientRequest, WPSInputs, DEFAULT_LOGGING_LEVEL
+from ._client import DEFAULT_LOGGING_LEVEL, TEMPLATE_FILES, ClientRequest, WPSInputs
 from ._data import CONFIG_SWARM
 from ._data_handling import ReturnedDataFile
 from ._wps.environment import JINJA2_ENVIRONMENT
@@ -1344,7 +1344,9 @@ class SwarmRequest(ClientRequest):
         "SwarmCI",
     ]
 
-    def __init__(self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL):
+    def __init__(
+        self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL
+    ):
         super().__init__(url, token, config, logging_level, server_type="Swarm")
 
         self._available = self._get_available_data()

--- a/src/viresclient/_client_swarm.py
+++ b/src/viresclient/_client_swarm.py
@@ -12,7 +12,7 @@ from warnings import warn
 from pandas import read_csv
 from tqdm import tqdm
 
-from ._client import TEMPLATE_FILES, ClientRequest, WPSInputs
+from ._client import TEMPLATE_FILES, ClientRequest, WPSInputs, DEFAULT_LOGGING_LEVEL
 from ._data import CONFIG_SWARM
 from ._data_handling import ReturnedDataFile
 from ._wps.environment import JINJA2_ENVIRONMENT
@@ -1344,7 +1344,7 @@ class SwarmRequest(ClientRequest):
         "SwarmCI",
     ]
 
-    def __init__(self, url=None, token=None, config=None, logging_level="NO_LOGGING"):
+    def __init__(self, url=None, token=None, config=None, logging_level=DEFAULT_LOGGING_LEVEL):
         super().__init__(url, token, config, logging_level, server_type="Swarm")
 
         self._available = self._get_available_data()

--- a/src/viresclient/_wps/wps.py
+++ b/src/viresclient/_wps/wps.py
@@ -221,7 +221,10 @@ class WPS10Service:
                 elm_reference = elm.find(
                     "./{http://www.opengis.net/wps/1.0.0}Reference"
                 )
-                return elm_reference.attrib["href"]
+                return (
+                    elm_reference.attrib.get("{http://www.w3.org/1999/xlink}href") or
+                    elm_reference.attrib["href"]
+                )
 
     def submit_async(self, request, content_type=None):
         """Send a POST WPS asynchronous request to a server and retrieve

--- a/src/viresclient/_wps/wps.py
+++ b/src/viresclient/_wps/wps.py
@@ -27,13 +27,14 @@
 # THE SOFTWARE.
 # -------------------------------------------------------------------------------
 
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
-from urllib.parse import urljoin
 from contextlib import closing
 from logging import LoggerAdapter, getLogger
 from time import sleep
+from urllib.error import HTTPError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
 from xml.etree import ElementTree
+
 from .time_util import Timer
 
 NS_OWS11 = "http://www.opengis.net/ows/1.1"
@@ -98,9 +99,10 @@ class WPS10Service:
         headers - optional dictionary of the HTTP headers sent with each
                   request
     """
+
     DEFAULT_CONTENT_TYPE = "application/xml; charset=utf-8"
-    RETRY_TIME = 20 # seconds
-    STATUS_POLL_RETRIES = 3 # re-try attempts
+    RETRY_TIME = 20  # seconds
+    STATUS_POLL_RETRIES = 3  # re-try attempts
 
     STATUS = {
         "{http://www.opengis.net/wps/1.0.0}ProcessAccepted": "ACCEPTED",
@@ -146,12 +148,12 @@ class WPS10Service:
         """
         timer = Timer()
         status, percentCompleted, status_url, execute_response = self.submit_async(
-            request, content_type=content_type,
+            request,
+            content_type=content_type,
         )
         wpsstatus = WPSStatus()
         wpsstatus.update(
-            status, percentCompleted, urljoin(self.url, status_url),
-            execute_response
+            status, percentCompleted, urljoin(self.url, status_url), execute_response
         )
 
         def log_wpsstatus(wpsstatus):
@@ -176,9 +178,7 @@ class WPS10Service:
 
                 last_status = wpsstatus.status
                 last_percentCompleted = wpsstatus.percentCompleted
-                wpsstatus.update(
-                    *self.poll_status(urljoin(self.url, wpsstatus.url))
-                )
+                wpsstatus.update(*self.poll_status(urljoin(self.url, wpsstatus.url)))
 
                 if wpsstatus.status != last_status:
                     log_wpsstatus(wpsstatus)
@@ -222,8 +222,8 @@ class WPS10Service:
                     "./{http://www.opengis.net/wps/1.0.0}Reference"
                 )
                 return (
-                    elm_reference.attrib.get("{http://www.w3.org/1999/xlink}href") or
-                    elm_reference.attrib["href"]
+                    elm_reference.attrib.get("{http://www.w3.org/1999/xlink}href")
+                    or elm_reference.attrib["href"]
                 )
 
     def submit_async(self, request, content_type=None):
@@ -250,7 +250,9 @@ class WPS10Service:
             if index == 0:
                 self.logger.debug("Polling asynchronous job status.")
             else:
-                self.logger.debug("Polling asynchronous job status. Retry attempt #%s.", index)
+                self.logger.debug(
+                    "Polling asynchronous job status. Retry attempt #%s.", index
+                )
 
             try:
                 return self._retrieve(
@@ -260,12 +262,15 @@ class WPS10Service:
                 if index < self.STATUS_POLL_RETRIES:
                     self.logger.error(
                         "Status poll failed. Retrying in %s seconds. %s: %s",
-                        self.RETRY_TIME, error.__class__.__name__, error
+                        self.RETRY_TIME,
+                        error.__class__.__name__,
+                        error,
                     )
                 else:
                     self.logger.error(
                         "Status poll failed. No more retries. %s: %s",
-                        error.__class__.__name__, error
+                        error.__class__.__name__,
+                        error,
                     )
                     raise
 


### PR DESCRIPTION
This PR introduces a couple of fixes to the WPS client:
- POST requests are now sent with the proper `application/xml` content type header. The server may start enforcing request with the proper content type in the future.
- The response references may contain `href` attribute with the namespace prefix `xlink:href`. The used WPS 1.0 standard seem to be somewhat ambiguous which one is correct and therefore, to make the parser more robust, both variants are accepted.
- Retry requests for the failed status update have been implemented. The client now repeats the failed job status polling 3 times with 20 seconds interval.
- In order to be able to inform users about the failed requests, the default logging level has been changed from `NO_LOGGING` to `ERROR`.
- The client now handles response references as relative URLs (encountered in local development environment). 